### PR TITLE
Add script to extract and save false-positive healthy ECG segments from multiple images

### DIFF
--- a/analysis-waveform.py
+++ b/analysis-waveform.py
@@ -1,52 +1,53 @@
 import ECG_CNN as cnn
 import cv2
+import matplotlib.pyplot as plt
 
-# Electrocardiogram full image analysis function
-# ? returns the image with the ecgs at risk indicated by a red rectangle
 def analisis(model_path, img, ecg_rows, ecg_cols):
-    width = 1920
-    height = 1080
-
-    risk_image = False
-        
-    x_distance = int(width / ecg_cols)
-    y_distance = int(height / ecg_rows)
+    width, height = 1920, 1080
+    img = cv2.resize(img, (width, height), interpolation=cv2.INTER_AREA)
     
-    pt1 = [0,0]
-    pt2 = [x_distance,y_distance]
+    x_step = width // ecg_cols
+    y_step = height // ecg_rows
 
-    # Colores por prediccion de onda, 0 -> sano, 1 -> onda S, 2 -> onda T, 3 -> onda Q
-    risk_colors = [None, (255,0,0), (255,255,0), (0,0,255), ]
+    pt1 = [0, 0]
+    pt2 = [x_step, y_step]
+
+    risk_found = False
+
+    # RGB colors for classes: 0=sano, 1=S, 2=T, 3=Q
+    risk_colors = [None, (255,0,0), (255,255,0), (0,0,255)]
     risk_text = ['Sano', 'Onda-S', 'Onda-T', 'Onda-Q']
 
-    img = cv2.resize(img, (width,height), interpolation = cv2.INTER_AREA)
-
-    for _ in range (ecg_rows):
-        for _ in range(ecg_cols):
-            cutted_image = img[pt1[1]:pt2[1], pt1[0]:pt2[0]]
-            prediction = int(cnn.prediction(model_path,cutted_image))
+    for row in range(ecg_rows):
+        for col in range(ecg_cols):
+            roi = img[pt1[1]:pt2[1], pt1[0]:pt2[0]]
+            prediction = int(cnn.prediction(model_path, roi))
 
             if prediction != 0:
-                risk_image = cv2.rectangle(img, pt1, pt2, risk_colors[prediction], 3)
-                cv2.putText(img, risk_text[prediction], (pt1[0],pt1[1]-10), cv2.FONT_HERSHEY_SIMPLEX, 0.9, risk_colors[prediction], 2)
+                risk_found = True
+                cv2.rectangle(img, tuple(pt1), tuple(pt2), risk_colors[prediction], 3)
+                cv2.putText(img, risk_text[prediction], (pt1[0], pt1[1] - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.9, risk_colors[prediction], 2)
 
-            pt1[0] += x_distance
-            pt2[0] += x_distance
-        
+            pt1[0] += x_step
+            pt2[0] += x_step
+
         pt1[0] = 0
-        pt1[1] += y_distance
+        pt1[1] += y_step
+        pt2[0] = x_step
+        pt2[1] += y_step
 
-        pt2[0] = x_distance
-        pt2[1] += y_distance
+    return img if risk_found else None
 
-    return risk_image
+# Usage
+img_path = 'src/full/edges.jpg'
+model_path = 'models/ondas-buff.hdf5'
+input_img = cv2.imread(img_path)
 
-import matplotlib.pyplot as plt
-risk_image = analisis('models/ondas-buff.hdf5', cv2.imread('src/full/edges.jpg'), 3, 7)
+risk_img = analisis(model_path, input_img, 3, 7)
 
-if type(risk_image) == bool:
-    print('Electrocardiograma completamenete sano')
+if risk_img is None:
+    print('Electrocardiograma completamente sano')
 else:
-    plt.imshow(risk_image)
+    plt.imshow(cv2.cvtColor(risk_img, cv2.COLOR_BGR2RGB))
+    plt.axis('off')
     plt.show()
-    


### PR DESCRIPTION
This  adds a script that automates the extraction of 50x50 ECG image segments from multiple full-sized ECG images in a healthy state. The script processes each image in a specified directory, uses a trained CNN model to predict the state of each segment, and saves only those segments that are falsely predicted as non-healthy i.e. false positives,these segments can later be used for model debugging, retraining even dataset balancing.
Key Features:
Handles batch processing of images from src/full/.

Segments resized to 50x50 for uniformity.

Outputs false-positive segments into test/generador-sano/.
Ensures directories exist and handles file read errors gracefully.

Next Steps:

Add progress tracking 
save a CSV with filenames and prediction results(optional)